### PR TITLE
allow scripts to accept plugin argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,19 @@ IMS Organization ID `export IMS_ORG=XXXXX`
 Then package the plugin as a zip folder.
 
 ```
-npm run package
+npm run build
 ```
 
 Next run the uploader. If you're updating the validation, be sure to update the version in your `plugin.json` manifest file.
 
 ```
 npm run upload
+```
+
+Optionally, a plugin argument can be provided to build or upload a single plugin.
+
+```
+npm run upload -- --plugin=adobe-analytics-compatible-version  
 ```
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-plugin-import": "^2.24.2",
+    "minimist": "^1.2.5",
     "ramda": "^0.27.1",
     "serve-static": "^1.14.1"
   }

--- a/plugins/adobe-analytics-debug-response-events/index.js
+++ b/plugins/adobe-analytics-debug-response-events/index.js
@@ -16,10 +16,15 @@
     aepMobile.lifecycleStart.matcher
   ]), events);
   const analyticsResponseEvents = match(aepMobile.analyticsResponse.matcher, events)
+    /* eslint-disable no-param-reassign */
     .reduce((map, event) => {
       const { requestEventIdentifier } = event.payload.ACPExtensionEventData;
-      return requestEventIdentifier ? { [requestEventIdentifier]: event, ...map } : map;
+      if (requestEventIdentifier) {
+        map[requestEventIdentifier] = event;
+      }
+      return map;
     }, {});
+    /* eslint-enable no-param-reassign */
 
   const matchedMessage = 'All Adobe Analytics events sent the debug flag!';
   const notMatchedEvents = [];

--- a/tasks/package.plugins.js
+++ b/tasks/package.plugins.js
@@ -12,11 +12,16 @@ governing permissions and limitations under the License.
 /* eslint no-console: 0 */
 
 const { execSync } = require('child_process');
+const minimist = require('minimist');
 const { resolve } = require('path');
 const plugins = require('./process.plugins');
 
-plugins.forEach((plugin) => {
-  const packageDir = resolve(__dirname, `../plugins/${plugin}`);
+const { plugin } = minimist(process.argv.slice(2));
+
+const targetPlugins = plugin ? [plugin] : plugins;
+
+targetPlugins.forEach((targetPlugin) => {
+  const packageDir = resolve(__dirname, `../plugins/${targetPlugin}`);
 
   const cwdOptions = {
     cwd: packageDir,

--- a/tasks/upload.plugins.js
+++ b/tasks/upload.plugins.js
@@ -13,16 +13,21 @@ governing permissions and limitations under the License.
 
 const { execSync } = require('child_process');
 const { readdirSync } = require('fs');
+const minimist = require('minimist');
 const { resolve } = require('path');
 const plugins = require('./process.plugins');
 
+const { plugin } = minimist(process.argv.slice(2));
+
+const targetPlugins = plugin ? [plugin] : plugins;
+
 const ZIP_NAME_REGEX = /\.zip$/;
 
-plugins.forEach((plugin) => {
-  const packageDir = resolve(__dirname, `../plugins/${plugin}`);
+targetPlugins.forEach((targetPlugin) => {
+  const packageDir = resolve(__dirname, `../plugins/${targetPlugin}`);
 
   const packageZips = readdirSync(packageDir)
-    .filter(file => ZIP_NAME_REGEX.test(file));
+    .filter((file) => ZIP_NAME_REGEX.test(file));
 
   const cwdOptions = {
     cwd: packageDir,
@@ -32,8 +37,8 @@ plugins.forEach((plugin) => {
   if (packageZips.length === 1) {
     execSync(`npx @adobe/griffon-uploader ${packageZips[0]}`, cwdOptions);
   } else {
-    const message = packageZips.length === 0 ? `No package zip found for plugin ${plugin}`
-      : `Could not determine which package zip to upload for plugin ${plugin}`;
+    const message = packageZips.length === 0 ? `No package zip found for plugin ${targetPlugin}`
+      : `Could not determine which package zip to upload for plugin ${targetPlugin}`;
     console.log(message);
   }
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow scripts to take a plugin argument.
Fix Adobe Analytics Debug Validation so Babel transpiles it to a single function.

## How Has This Been Tested?

Within the Validation Summary plugin

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
