### PR TITLE
feat: :recycle: update iam requirements to not include optimize

### DIFF
--- a/plugins/aep-iam-dependencies/index.ts
+++ b/plugins/aep-iam-dependencies/index.ts
@@ -61,20 +61,12 @@ import { ValidationPluginResult } from '../../types/validationPlugin';
     return installed && installed >= '1.1.0';
   });
 
-  const isOptimizeInstalled = versionEvents.some((version) => {
-    const installed = versions.getExtensionsKey('"com.adobe.optimize"')(
-      version
-    );
-    return installed && installed >= '1.0.0';
-  });
-
   const isValid =
     isCoreInstalled &&
     isEdgeInstalled &&
     isEdgeConsentInstalled &&
     isEdgeIdentityInstalled &&
-    isMessagingInstalled &&
-    isOptimizeInstalled;
+    isMessagingInstalled;
 
   return isValid
     ? {

--- a/plugins/aep-iam-dependencies/plugin.test.ts
+++ b/plugins/aep-iam-dependencies/plugin.test.ts
@@ -17,10 +17,6 @@ const versions = sharedStateVersions.mock({
             version: '1.0.1',
             friendlyName: 'Edge Identity'
           },
-          'com.adobe.optimize': {
-            version: '1.0.0',
-            friendlyName: 'Optimize'
-          },
           'com.adobe.module.lifecycle': {
             version: '3.4.2',
             friendlyName: 'Lifecycle'


### PR DESCRIPTION
## Description

With some Architecture updates, Optimize is not longer required to use IAM

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
