### PR TITLE
add validation for identity extensions

### DIFF
--- a/plugins/identity-installed/index.ts
+++ b/plugins/identity-installed/index.ts
@@ -1,0 +1,57 @@
+/*
+  Copyright 2022 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+import { SharedStateVersions } from '@adobe/griffon-toolkit-aep-mobile';
+import { Event } from '@adobe/griffon-toolkit-common';
+import { ValidationPluginResult } from '../../types/validationPlugin';
+
+(function (events: Event[]): ValidationPluginResult {
+  const { toolkit: kit } = window.griffon;
+  const { sharedStateVersions } = kit['aep-mobile'];
+  const found = kit.match(
+    sharedStateVersions.matcher,
+    events
+  ) as SharedStateVersions[];
+  const latest = found[0];
+  const extensions = sharedStateVersions.getExtensions(latest);
+
+  const identity = extensions['com.adobe.module.identity'];
+  const edgeIdentity = extensions['com.adobe.edge.identity'];
+  const edge = extensions['com.adobe.edge'];
+
+  const solution =
+    extensions['com.adobe.module.analytics'] ||
+    extensions['com.adobe.module.target'] ||
+    extensions['com.adobe.module.places'] ||
+    extensions['com.adobe.module.campaign'];
+
+  const isIdentityValid = (solution && identity) || !solution;
+  const isEdgeIdentityValid = (edge && edgeIdentity) || !edge;
+
+  const isBothIdentityValid = isIdentityValid && isEdgeIdentityValid;
+
+  return {
+    message: isBothIdentityValid
+      ? 'The Identity extension(s) have been registered correctly.'
+      : !isIdentityValid
+      ? 'The Identity extension for Experience Cloud ID Service is required for Experience Cloud solution extensions, such as Analytics and Target'
+      : 'To use Adobe Experience Platform Edge Network, you need to install and register the Identity for Edge Network extension.',
+    events: [latest.uuid],
+    links: [
+      {
+        type: 'doc',
+        url: 'https://developer.adobe.com/client-sdks/documentation/identity-for-edge-network/faq/#q-i-am-using-aep-edge-and-adobe-solutions-extensions-which-identity-extension-should-i-install-and-register'
+      }
+    ],
+    result: isBothIdentityValid ? 'matched' : 'not matched'
+  };
+});

--- a/plugins/identity-installed/index.ts
+++ b/plugins/identity-installed/index.ts
@@ -30,6 +30,7 @@ import { ValidationPluginResult } from '../../types/validationPlugin';
 
   const solution =
     extensions['com.adobe.module.analytics'] ||
+    extensions['com.adobe.module.media'] ||
     extensions['com.adobe.module.target'] ||
     extensions['com.adobe.module.places'] ||
     extensions['com.adobe.module.campaign'];

--- a/plugins/identity-installed/plugin.json
+++ b/plugins/identity-installed/plugin.json
@@ -1,0 +1,10 @@
+{
+  "category": "Identity",
+  "displayName": "Verifies if the Identity or Identity for Edge Network are required and registered.",
+  "description": "Verifies if both the Identity and Identity for Edge Network extensions are required. If the extension is required it verifies if it is registered.",
+  "namespace": "identity-installed",
+  "src": "dist/index.js",
+  "type": "validation",
+  "version": "0.0.1",
+  "visibility": ["PUBLIC"]
+}

--- a/plugins/identity-installed/plugin.test.ts
+++ b/plugins/identity-installed/plugin.test.ts
@@ -1,0 +1,104 @@
+import {
+  sharedStateVersions,
+  SharedStateVersions
+} from '@adobe/griffon-toolkit-aep-mobile';
+// @ts-ignore
+import plugin from './index';
+
+const bothIdentityValid = sharedStateVersions.mock({
+  uuid: '1',
+  payload: {
+    metadata: {
+      'state.data': {
+        extensions: {
+          'com.adobe.module.analytics': {
+            version: '1.2.10'
+          },
+          'com.adobe.module.identity': {
+            version: '1.3.2'
+          },
+          'com.adobe.edge': {
+            version: '1.4.0'
+          },
+          'com.adobe.edge.identity': {
+            version: '1.1.0'
+          }
+        },
+        version: '3.0.0'
+      }
+    }
+  }
+}) as SharedStateVersions;
+
+const edgeIdentityInvalid = sharedStateVersions.mock({
+  uuid: '1',
+  payload: {
+    metadata: {
+      'state.data': {
+        extensions: {
+          'com.adobe.module.analytics': {
+            version: '1.2.10'
+          },
+          'com.adobe.module.identity': {
+            version: '1.3.2'
+          },
+          'com.adobe.edge': {
+            version: '1.4.0'
+          }
+        },
+        version: '3.0.0'
+      }
+    }
+  }
+}) as SharedStateVersions;
+
+const coreIdentityInvalid = sharedStateVersions.mock({
+  uuid: '1',
+  payload: {
+    metadata: {
+      'state.data': {
+        extensions: {
+          'com.adobe.module.analytics': {
+            version: '1.2.10'
+          },
+          'com.adobe.edge': {
+            version: '1.4.0'
+          },
+          'com.adobe.edge.identity': {
+            version: '1.1.0'
+          }
+        },
+        version: '3.0.0'
+      }
+    }
+  }
+}) as SharedStateVersions;
+
+describe('Identity Extensions Installed', () => {
+  it('should match when the Identity and Identity for Edge Network extensions have been installed', () => {
+    const result = plugin([bothIdentityValid]);
+
+    expect(result).toMatchObject({
+      events: ['1'],
+      result: 'matched'
+    });
+  });
+
+  it('should not match when the Edge Network extension is installed but the Identity for Edge Network extension is not', () => {
+    const result = plugin([edgeIdentityInvalid]);
+
+    expect(result).toMatchObject({
+      events: ['1'],
+      result: 'not matched'
+    });
+  });
+
+  it('should not match when an Experience Cloud solution extension is installed but the core Identity extension is not', () => {
+    const result = plugin([coreIdentityInvalid]);
+
+    expect(result).toMatchObject({
+      events: ['1'],
+      result: 'not matched'
+    });
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a validation to check if the Identity Extension for Experience Cloud and the Identity Extension for Edge Network have been installed and registered.

## Related Issue

Help customers identify which Identity extensions need to be registered.

https://jira.corp.adobe.com/browse/MOB-17818?focusedCommentId=34050547&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-34050547

https://developer.adobe.com/client-sdks/documentation/identity-for-edge-network/faq/#q-i-am-using-aep-edge-and-adobe-solutions-extensions-which-identity-extension-should-i-install-and-register

## Motivation and Context

Recently, a customer wasn't getting Analytics Response events in Assurance Tools and we discovered that while they had Identity configured for Edge Network they did not have the core Identity extension for Experience Cloud solutions like Analytics.

## How Has This Been Tested?

Unit tests and in the validation editor

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
