### PR TITLE
For Analytics, check every event for optedin privacy status

### DIFF
--- a/plugins/adobe-analytics-response-events/index.ts
+++ b/plugins/adobe-analytics-response-events/index.ts
@@ -61,7 +61,7 @@ import { ValidationPluginResult } from '../../types/validationPlugin';
       aepMobile.configuration.matcher,
       events
     );
-    const optedin = configurationEvents.some((event) => {
+    const optedin = configurationEvents.every((event) => {
       const eventData = aepMobile.configuration.getEventData(event);
       const privacy =
         eventData['global.privacy'] ||
@@ -73,8 +73,8 @@ import { ValidationPluginResult } from '../../types/validationPlugin';
       notMatchedMessage +=
         ' If your report suite is not timestamp enabled, hits are discarded until the privacy status changes to `optedin`';
       links.push({
-        typed: 'doc',
-        url: 'https://aep-sdks.gitbook.io/docs/resources/privacy-and-gdpr#using-adobe-experience-cloud-solution-extensions'
+        type: 'doc',
+        url: 'https://developer.adobe.com/client-sdks/documentation/adobe-analytics/faq/#verify-current-privacy-status'
       });
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The state for privacy should always be `optedin` if the validator detects missing response events.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

In QA against customer session

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
