### PR TITLE
Deprecate edge messages

### DIFF
--- a/plugins/aep-edge-analytics-streaming-validation/index.ts
+++ b/plugins/aep-edge-analytics-streaming-validation/index.ts
@@ -40,12 +40,20 @@ import { ValidationPluginResult } from '../../types/validationPlugin';
       events
     );
 
+  const findNewValidationEvent = (requestId: string) =>
+    toolkit.search(
+      "[?vendor == 'com.adobe.streaming.validation' " +
+        `&& payload.header.msgId == '${requestId}']`,
+      events
+    );
+
   hits.forEach((hit) => {
     const requestId: string = toolkit.edge.analyticsHit.get(
       toolkit.edge.analyticsHit.path.requestId,
       hit
     );
-    const validation = findValidationEvent(requestId);
+    const validation =
+      findValidationEvent(requestId) || findNewValidationEvent(requestId);
     if (!validation.length) {
       const hitReceived = toolkit.match(
         getHitReceivedMatcher(requestId),

--- a/plugins/aep-edge-mobile-track-hits/index.ts
+++ b/plugins/aep-edge-mobile-track-hits/index.ts
@@ -36,9 +36,14 @@ import { ValidationPluginResult } from '../../types/validationPlugin';
     for (let j = 0; j < edgeHits.length; j++) {
       const edgeHit = edgeHits[j];
       const messages = toolkit.edge.edgeEvent.getMessages(edgeHit);
-      const message = (messages && messages[1]) || '';
+      let data;
+      try {
+        data = messages ? JSON.parse(messages[1]) : val.payload;
+      } catch {
+        data = val.payload;
+      }
 
-      if (message.indexOf(identifier) > -1) {
+      if (data.indexOf(identifier) > -1) {
         linked = true;
         break;
       }

--- a/plugins/aep-edge-streaming-validation/index.ts
+++ b/plugins/aep-edge-streaming-validation/index.ts
@@ -30,11 +30,9 @@ import { ValidationPluginResult } from '../../types/validationPlugin';
     const messages = toolkit.edge.streamingValidation.getMessages(val);
     let data;
     try {
-      data = messages
-        ? JSON.parse(messages[1])
-        : assuranceEvent.getPayload(val);
+      data = messages ? JSON.parse(messages[1]) : val.payload;
     } catch {
-      data = assuranceEvent.getPayload(val);
+      data = val.payload;
     }
 
     if (data._errors) {

--- a/plugins/aep-edge-streaming-validation/index.ts
+++ b/plugins/aep-edge-streaming-validation/index.ts
@@ -28,13 +28,19 @@ import { ValidationPluginResult } from '../../types/validationPlugin';
 
   vals.forEach((val) => {
     const messages = toolkit.edge.streamingValidation.getMessages(val);
-    const streamingValidationMessage = JSON.parse(messages[1]);
+    let data;
+    try {
+      data = messages
+        ? JSON.parse(messages[1])
+        : assuranceEvent.getPayload(val);
+    } catch {
+      data = assuranceEvent.getPayload(val);
+    }
 
-    if (streamingValidationMessage._errors) {
+    if (data._errors) {
       errors.push(val.uuid);
 
-      const errorMessage =
-        streamingValidationMessage?._errors?._streamingValidation?.[0].message;
+      const errorMessage = data?._errors?._streamingValidation?.[0].message;
 
       if (errorMessages.indexOf(errorMessage) === -1) {
         errorMessages.push(errorMessage);


### PR DESCRIPTION
Konductor is changing how messages/data is being sent into Assurance

## Description

Konductor used to send in data for streaming validation events in a messages array. The data will now be contained in the payload object.

## How Has This Been Tested?

In the Validation Editor

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
