### PR TITLE
fix android versions compatible logic

### DIFF
--- a/plugins/adobe-analytics-compatible-version/index.ts
+++ b/plugins/adobe-analytics-compatible-version/index.ts
@@ -48,16 +48,13 @@ import { ValidationPluginResult } from 'types/validationPlugin';
   const isAndroidCompatible = (
     assuranceVersionMatches: string[],
     analyticsVersionMatches: string[]
-  ) => {
-    const assuranceVersionValid = parseInt(assuranceVersionMatches[1], 10) >= 1;
-    const analyticsVersionValid =
-      parseInt(analyticsVersionMatches[1], 10) > 1 ||
+  ) =>
+    parseInt(assuranceVersionMatches[1], 10) >= 1 &&
+    (parseInt(analyticsVersionMatches[1], 10) > 1 ||
       (parseInt(analyticsVersionMatches[1], 10) === 1 &&
         (parseInt(analyticsVersionMatches[2], 10) > 2 ||
           (parseInt(analyticsVersionMatches[2], 10) === 2 &&
-            parseInt(analyticsVersionMatches[3], 10) >= 6)));
-    return assuranceVersionValid && analyticsVersionValid;
-  };
+            parseInt(analyticsVersionMatches[3], 10) >= 6))));
 
   const isIOSCompatible = (
     assuranceVersionMatches: string[],

--- a/plugins/adobe-analytics-compatible-version/index.ts
+++ b/plugins/adobe-analytics-compatible-version/index.ts
@@ -48,13 +48,16 @@ import { ValidationPluginResult } from 'types/validationPlugin';
   const isAndroidCompatible = (
     assuranceVersionMatches: string[],
     analyticsVersionMatches: string[]
-  ) =>
-    (parseInt(assuranceVersionMatches[1], 10) >= 1 &&
-      parseInt(analyticsVersionMatches[1], 10) > 1) ||
-    (parseInt(analyticsVersionMatches[1], 10) === 1 &&
-      (parseInt(analyticsVersionMatches[2], 10) > 2 ||
-        (parseInt(analyticsVersionMatches[2], 10) === 2 &&
-          parseInt(analyticsVersionMatches[3], 10) >= 6)));
+  ) => {
+    const assuranceVersionValid = parseInt(assuranceVersionMatches[1], 10) >= 1;
+    const analyticsVersionValid =
+      parseInt(analyticsVersionMatches[1], 10) > 1 ||
+      (parseInt(analyticsVersionMatches[1], 10) === 1 &&
+        (parseInt(analyticsVersionMatches[2], 10) > 2 ||
+          (parseInt(analyticsVersionMatches[2], 10) === 2 &&
+            parseInt(analyticsVersionMatches[3], 10) >= 6)));
+    return assuranceVersionValid && analyticsVersionValid;
+  };
 
   const isIOSCompatible = (
     assuranceVersionMatches: string[],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix Android Versions Compatible logic 

## Motivation and Context

If Assurance extension was missing the validator still return `matched`

## How Has This Been Tested?

In QA with session that should return `not matched`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
