### PR TITLE
feat: :sparkles: adds iam consent validation plugin

### DIFF
--- a/plugins/aep-iam-consent/index.ts
+++ b/plugins/aep-iam-consent/index.ts
@@ -1,0 +1,90 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+import {
+  Configuration,
+  SharedStateVersions
+} from '@adobe/griffon-toolkit-aep-mobile';
+import { Event } from '@adobe/griffon-toolkit-common';
+import { ValidationPluginResult } from '../../types/validationPlugin';
+
+(function (events: Event[]): ValidationPluginResult {
+  const { toolkit: kit } = window.griffon;
+  const { configuration } = kit['aep-mobile'];
+
+  const configurations: Configuration[] = kit.match(
+    configuration.matcher,
+    events
+  );
+
+  const isConsentActive = configurations.some(
+    (event) => event.payload.metadata?.['state.data']?.['consent.default']
+  );
+
+  const { sharedStateVersions: versions } = kit['aep-mobile'];
+  const versionEvents = kit.match(
+    versions.matcher,
+    events
+  ) as SharedStateVersions[];
+
+  const isConsentInstalled = versionEvents.some(
+    versions.getExtensionsKey('"com.adobe.edge.consent"')
+  );
+
+  if (!isConsentActive && !isConsentInstalled) {
+    return {
+      message:
+        'Consent has not been installed or enabled, it will not be be used by the SDK',
+      result: 'unknown',
+      links: [
+        {
+          type: 'doc',
+          url: 'https://developer.adobe.com/client-sdks/documentation/consent-for-edge-network/'
+        }
+      ]
+    };
+  }
+
+  if (isConsentActive && !isConsentInstalled) {
+    return {
+      message:
+        'The Consent extension is configured inside Data Collection, but the SDK extension is not registered in your application.',
+      result: 'not matched',
+      links: [
+        {
+          type: 'doc',
+          url: 'https://developer.adobe.com/client-sdks/documentation/consent-for-edge-network/'
+        }
+      ]
+    };
+  }
+
+  if (!isConsentActive && isConsentInstalled) {
+    return {
+      message:
+        'The Consent SDK extension is registered in your application, but is not configured inside Data Collection.',
+      result: 'not matched',
+      links: [
+        {
+          type: 'doc',
+          url: 'https://developer.adobe.com/client-sdks/documentation/consent-for-edge-network/'
+        }
+      ]
+    };
+  }
+
+  return {
+    message:
+      'Consent configuration in Adobe Data Collection and the AEP SDK is valid for your application.',
+    result: 'matched'
+  };
+});

--- a/plugins/aep-iam-consent/plugin.json
+++ b/plugins/aep-iam-consent/plugin.json
@@ -1,0 +1,15 @@
+{
+  "category": "AEP IAM",
+  "displayName": "Adobe Journey Optimizer In App Messaging Consent",
+  "description": "Validates Consent is registered and configured correctly for use in AJO Messaging",
+  "namespace": "aep-iam-consent",
+  "src": "dist/index.js",
+  "type": "validation",
+  "version": "0.0.1",
+  "visibility": [
+    "972C898555E9F7BC7F000101@AdobeOrg",
+    "056F3DD059CB22060A494021@AdobeOrg",
+    "692D3C645C5CDA980A495CB3@AdobeOrg",
+    "906E3A095DC834230A495FD6@AdobeOrg"
+  ]
+}

--- a/plugins/aep-iam-consent/plugin.test.ts
+++ b/plugins/aep-iam-consent/plugin.test.ts
@@ -1,0 +1,59 @@
+import { ValidationPluginResult } from 'types/validationPlugin';
+import {
+  configuration,
+  sharedStateVersions
+} from '@adobe/griffon-toolkit-aep-mobile';
+// @ts-ignore
+import plugin from './index';
+
+const configEvent = configuration.mock({
+  payload: {
+    metadata: {
+      'state.data': {
+        'consent.default': {
+          consents: {
+            collect: {
+              val: 'y'
+            }
+          }
+        }
+      }
+    }
+  }
+});
+
+const versionsEvent = sharedStateVersions.mock({
+  payload: {
+    metadata: {
+      'state.data': {
+        extensions: {
+          'com.adobe.edge.consent': {
+            version: '1.0.0'
+          }
+        }
+      }
+    }
+  }
+});
+
+describe('AEP IAM Consent', () => {
+  it('should validate consent is configured and registered', () => {
+    const result: ValidationPluginResult = plugin([configEvent, versionsEvent]);
+    expect(result.result).toBe('matched');
+  });
+
+  it('should error when consent is configured but not registered', () => {
+    const result: ValidationPluginResult = plugin([configEvent]);
+    expect(result.result).toBe('not matched');
+  });
+
+  it('should error when consent is not configured but registered', () => {
+    const result: ValidationPluginResult = plugin([versionsEvent]);
+    expect(result.result).toBe('not matched');
+  });
+
+  it("should warn when consent isn't installed or registered", () => {
+    const result: ValidationPluginResult = plugin([]);
+    expect(result.result).toBe('unknown');
+  });
+});

--- a/plugins/aep-iam-dependencies/index.ts
+++ b/plugins/aep-iam-dependencies/index.ts
@@ -75,7 +75,7 @@ import { ValidationPluginResult } from '../../types/validationPlugin';
         result: 'matched'
       }
     : {
-        message: `Missing required extensions for In App Messaging. Please ensure the following extensions are installed: AEP Core >= 3.4.2, AEP Edge >= 1.3.0, AEP Edge Consent >= 1.0.0, AEP Edge Identity >= 1.0.1, AEP Messaging >= 1.1.0, and AEP Optimize >= 1.0.0`,
+        message: `Missing required extensions for In App Messaging. Please ensure the following extensions are installed: AEP Core >= 3.4.2, AEP Edge >= 1.3.0, AEP Edge Consent >= 1.0.0, AEP Edge Identity >= 1.0.1, and AEP Messaging >= 1.1.0`,
         events: [],
         result: 'not matched'
       };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a new validator for IAM consent

## Motivation and Context

Validates when consent is active, messaging has been configured to use it properly

## How Has This Been Tested?
Unit tests added for all possible results

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
