### PR TITLE
Fix the error for the compatible version test when there is no Analytics extension installed

### DIFF
--- a/plugins/adobe-analytics-compatible-version/index.ts
+++ b/plugins/adobe-analytics-compatible-version/index.ts
@@ -71,6 +71,7 @@ import { ValidationPluginResult } from 'types/validationPlugin';
     const extensions = versions.getExtensions(version);
     return extensions?.['com.adobe.edge.bridge'];
   });
+
   const compatible = edgeBridgeVersion
     ? true
     : versionEvents.every((event) => {
@@ -104,9 +105,9 @@ import { ValidationPluginResult } from 'types/validationPlugin';
           "No version info could be found. Either the Assurance SDK isn't registered or the SDK did not pass in cached events upon activating.",
         result: 'unknown'
       }
-    : !compatible
+    : !compatible && analyticsVersion
     ? {
-        message: `Assurance SDK Version ${assuranceVersion} and Adobe Analytics Extension version ${analyticsVersion} are not compatible!`,
+        message: `Assurance SDK Version ${assuranceVersion} and Adobe Analytics extension version ${analyticsVersion} are not compatible!`,
         links: [
           {
             type: 'doc',
@@ -120,13 +121,19 @@ import { ValidationPluginResult } from 'types/validationPlugin';
     ? {
         events: [],
         message:
-          'The installed Assurance SDK and Analytics Edge Bridge Extensions are compatible.',
+          'The installed Assurance SDK and Analytics Edge Bridge extensions are compatible.',
         result: 'matched'
       }
+    : !analyticsVersion
+    ? {
+      message: 'The Analytics extension or Edge Bridge extension are not installed, nothing to validate.',
+      events: [],
+      result: 'matched'
+    }  
     : {
         events: [],
         message:
-          'The installed Assurance SDK and Adobe Analytics Extensions are compatible.',
+          'The installed Assurance SDK and Adobe Analytics extensions are compatible.',
         result: 'matched'
       };
 });

--- a/plugins/adobe-analytics-compatible-version/index.ts
+++ b/plugins/adobe-analytics-compatible-version/index.ts
@@ -107,7 +107,7 @@ import { ValidationPluginResult } from 'types/validationPlugin';
       }
     : !compatible && analyticsVersion
     ? {
-        message: `Assurance SDK Version ${assuranceVersion} and Adobe Analytics extension version ${analyticsVersion} are not compatible!`,
+        message: `Assurance SDK Version ${assuranceVersion} and Adobe Analytics extension version ${analyticsVersion} are not compatible. Check the link for latest versions available and upgrade to resolve this error.`,
         links: [
           {
             type: 'doc',

--- a/plugins/adobe-analytics-compatible-version/index.ts
+++ b/plugins/adobe-analytics-compatible-version/index.ts
@@ -126,9 +126,9 @@ import { ValidationPluginResult } from 'types/validationPlugin';
       }
     : !analyticsVersion
     ? {
-      message: 'The Analytics and Edge Bridge extensions are not installed, nothing to validate.',
+      message: 'The compatibility versions between Adobe Analytics and Assurance SDK cannot be determined as the Adobe Analytics extensions is not installed.',
       events: [],
-      result: 'matched'
+      result: 'unknown'
     }  
     : {
         events: [],

--- a/plugins/adobe-analytics-compatible-version/index.ts
+++ b/plugins/adobe-analytics-compatible-version/index.ts
@@ -126,7 +126,7 @@ import { ValidationPluginResult } from 'types/validationPlugin';
       }
     : !analyticsVersion
     ? {
-      message: 'The compatibility versions between Adobe Analytics and Assurance SDK cannot be determined as the Adobe Analytics extensions is not installed.',
+      message: 'The compatibility versions between Adobe Analytics and Assurance SDK cannot be determined as the Adobe Analytics extension is not installed.',
       events: [],
       result: 'unknown'
     }  

--- a/plugins/adobe-analytics-compatible-version/index.ts
+++ b/plugins/adobe-analytics-compatible-version/index.ts
@@ -121,12 +121,12 @@ import { ValidationPluginResult } from 'types/validationPlugin';
     ? {
         events: [],
         message:
-          'The installed Assurance SDK and Analytics Edge Bridge extensions are compatible.',
+          'The installed Assurance SDK and Edge Bridge extensions are compatible.',
         result: 'matched'
       }
     : !analyticsVersion
     ? {
-      message: 'The Analytics extension or Edge Bridge extension are not installed, nothing to validate.',
+      message: 'The Analytics and Edge Bridge extensions are not installed, nothing to validate.',
       events: [],
       result: 'matched'
     }  

--- a/plugins/adobe-analytics-compatible-version/plugin.json
+++ b/plugins/adobe-analytics-compatible-version/plugin.json
@@ -5,6 +5,6 @@
   "namespace": "adobe-analytics-compatible-version",
   "src": "dist/index.js",
   "type": "validation",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "visibility": ["PUBLIC"]
 }

--- a/plugins/adobe-analytics-compatible-version/plugin.test.ts
+++ b/plugins/adobe-analytics-compatible-version/plugin.test.ts
@@ -53,6 +53,23 @@ const edgeBridgeVersionEvent = sharedStateVersions.mock({
   }
 }) as SharedStateVersions;
 
+
+const noAnalyticsVersionEvent = sharedStateVersions.mock({
+  uuid: '1',
+  payload: {
+    metadata: {
+      'state.data': {
+        extensions: {
+          'com.adobe.assurance': {
+            version: '3.0.0'
+          },
+        },
+        version: '3.0.0'
+      }
+    }
+  }
+}) as SharedStateVersions;
+
 const invalidVersionEvent = sharedStateVersions.mock({
   uuid: '1',
   payload: {
@@ -146,6 +163,16 @@ describe('Adobe Analytics Compatible Version', () => {
     expect(result).toMatchObject({
       events: [],
       result: 'unknown'
+    });
+  });
+
+  it('should return valid when no analytics version events are found', () => {
+    const result = plugin([noAnalyticsVersionEvent]);
+
+    expect(result).toMatchObject({
+      message: 'The Analytics extension or Edge Bridge extension are not installed, nothing to validate.',
+      events: [],
+      result: 'matched'
     });
   });
 

--- a/plugins/adobe-analytics-compatible-version/plugin.test.ts
+++ b/plugins/adobe-analytics-compatible-version/plugin.test.ts
@@ -54,7 +54,7 @@ const edgeBridgeVersionEvent = sharedStateVersions.mock({
 }) as SharedStateVersions;
 
 
-const noAnalyticsVersionEvent = sharedStateVersions.mock({
+const noAnalyticsVersion = sharedStateVersions.mock({
   uuid: '1',
   payload: {
     metadata: {
@@ -167,11 +167,11 @@ describe('Adobe Analytics Compatible Version', () => {
     });
   });
 
-  it('should return unknown when no analytics version events are found', () => {
-    const result = plugin([noAnalyticsVersionEvent]);
+  it('should return unknown when no analytics version is found in the shared state', () => {
+    const result = plugin([noAnalyticsVersion]);
 
     expect(result).toMatchObject({
-      message: 'The compatibility versions between Adobe Analytics and Assurance SDK cannot be determined as the Adobe Analytics extensions is not installed.',
+      message: 'The compatibility versions between Adobe Analytics and Assurance SDK cannot be determined as the Adobe Analytics extension is not installed.',
       events: [],
       result: 'unknown'
     });

--- a/plugins/adobe-analytics-compatible-version/plugin.test.ts
+++ b/plugins/adobe-analytics-compatible-version/plugin.test.ts
@@ -170,9 +170,9 @@ describe('Adobe Analytics Compatible Version', () => {
     const result = plugin([noAnalyticsVersionEvent]);
 
     expect(result).toMatchObject({
-      message: 'The Analytics and Edge Bridge extensions are not installed, nothing to validate.',
+      message: 'The compatibility versions between Adobe Analytics and Assurance SDK cannot be determined as the Adobe Analytics extensions is not installed.',
       events: [],
-      result: 'matched'
+      result: 'unknown'
     });
   });
 

--- a/plugins/adobe-analytics-compatible-version/plugin.test.ts
+++ b/plugins/adobe-analytics-compatible-version/plugin.test.ts
@@ -170,7 +170,7 @@ describe('Adobe Analytics Compatible Version', () => {
     const result = plugin([noAnalyticsVersionEvent]);
 
     expect(result).toMatchObject({
-      message: 'The Analytics extension or Edge Bridge extension are not installed, nothing to validate.',
+      message: 'The Analytics and Edge Bridge extensions are not installed, nothing to validate.',
       events: [],
       result: 'matched'
     });

--- a/plugins/adobe-analytics-compatible-version/plugin.test.ts
+++ b/plugins/adobe-analytics-compatible-version/plugin.test.ts
@@ -162,11 +162,12 @@ describe('Adobe Analytics Compatible Version', () => {
 
     expect(result).toMatchObject({
       events: [],
+      message:  "No version info could be found. Either the Assurance SDK isn't registered or the SDK did not pass in cached events upon activating.",
       result: 'unknown'
     });
   });
 
-  it('should return valid when no analytics version events are found', () => {
+  it('should return unknown when no analytics version events are found', () => {
     const result = plugin([noAnalyticsVersionEvent]);
 
     expect(result).toMatchObject({


### PR DESCRIPTION
Taking care of the case for the compatible version test when there is no Analytics extension installed. (MOB-19438)

<!--- Provide a general summary of your changes in the Title above -->

## Description


<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
