### PR TITLE
Update for adobe-analytics-configuration validation.

### DIFF
--- a/plugins/adobe-analytics-configuration/index.ts
+++ b/plugins/adobe-analytics-configuration/index.ts
@@ -51,6 +51,6 @@ import { ValidationPluginResult } from '../../types/validationPlugin';
     :{
       message: 'no Analytics extension is detected, nothing to validate.',
       events: [],
-      result: 'matched'
+      result: 'unknown'
     };
 });

--- a/plugins/adobe-analytics-configuration/plugin.test.ts
+++ b/plugins/adobe-analytics-configuration/plugin.test.ts
@@ -50,7 +50,7 @@ const invalidConfigurationEmpty = sharedStateConfig.mock({
   }
 }) as SharedStateConfig;
 
-const invalidConfiguration = sharedStateConfig.mock({
+const invalidConfigurationBlank = sharedStateConfig.mock({
   uuid: '2',
   payload: {
     ACPExtensionEventData: {
@@ -78,7 +78,7 @@ const analyticsVersionEvent = sharedStateVersions.mock({
 describe('Adobe Analytics Configuration', () => {
   it('should return success when analytics has been configured correctly in at least one event', () => {
     const result: ValidationPluginResult = plugin([
-      invalidConfiguration,
+      invalidConfigurationBlank,
       inValidConfigurationNoRsid,
       validConfiguration
     ]);

--- a/plugins/adobe-analytics-configuration/plugin.test.ts
+++ b/plugins/adobe-analytics-configuration/plugin.test.ts
@@ -96,7 +96,7 @@ describe('Adobe Analytics Configuration', () => {
     expect(result).toMatchObject({
       events: [],
       message:'no Analytics extension is detected, nothing to validate.',
-      result: 'matched'
+      result: 'unknown'
     });
   });
 

--- a/plugins/adobe-analytics-configuration/plugin.test.ts
+++ b/plugins/adobe-analytics-configuration/plugin.test.ts
@@ -1,36 +1,46 @@
 import {
-  configuration,
-  Configuration
+  SharedStateConfig,
+  sharedStateConfig,
+  SharedStateVersions,
+  sharedStateVersions
 } from '@adobe/griffon-toolkit-aep-mobile';
 import { ValidationPluginResult } from 'types/validationPlugin';
 // @ts-ignore
 import plugin from './index';
 
-const validConfiguration = configuration.mock({
+const validConfiguration = sharedStateConfig.mock({
+  uuid: '1',
+  payload: {
+    "metadata": {
+      "state.data": {
+        "analytics.rsids": "123",
+        "analytics.server": "123",
+        'global.privacy': 'optedin'
+      }
+    },
+  }
+}) as SharedStateConfig;
+
+
+const inValidConfigurationNoServer = sharedStateConfig.mock({
   uuid: '1',
   payload: {
     ACPExtensionEventData: {
-      'analytics.rsids': '123',
+      'analytics.rsids': '123'
+    }
+  }
+}) as SharedStateConfig;
+
+const inValidConfigurationNoRsid = sharedStateConfig.mock({
+  uuid: '1',
+  payload: {
+    ACPExtensionEventData: {
       'analytics.server': '123'
     }
   }
-}) as Configuration;
+}) as SharedStateConfig;
 
-const alsoValidConfiguration = configuration.mock({
-  uuid: '4',
-  payload: {
-    metadata: {
-      'state.data': {
-        'analytics.rsids': 'rsids',
-        'global.privacy': 'optedin',
-        'analytics.launchHitDelay': 0,
-        'analytics.server': 'analytics.server'
-      }
-    }
-  }
-}) as Configuration;
-
-const invalidConfiguration = configuration.mock({
+const invalidConfigurationEmpty = sharedStateConfig.mock({
   uuid: '2',
   payload: {
     ACPExtensionEventData: {
@@ -38,57 +48,94 @@ const invalidConfiguration = configuration.mock({
       'analytics.server': ''
     }
   }
-});
+}) as SharedStateConfig;
 
-const invalidConfigurationMissingEventData = configuration.mock({
-  uuid: '3',
+const invalidConfiguration = sharedStateConfig.mock({
+  uuid: '2',
   payload: {
-    ACPExtensionEventData: {}
+    ACPExtensionEventData: {
+    }
   }
-}) as Configuration;
+}) as SharedStateConfig;
+
+const analyticsVersionEvent = sharedStateVersions.mock({
+  uuid: '1',
+  payload: {
+    metadata: {
+      'state.data': {
+        extensions: {
+          'com.adobe.module.analytics': {
+            version: '4.0.0'
+          }
+        },
+        version: '4.0.0'
+      }
+    }
+  }
+}) as SharedStateVersions;
+
 
 describe('Adobe Analytics Configuration', () => {
-  it('should return success when target has been configured correctly in at least one event', () => {
+  it('should return success when analytics has been configured correctly in at least one event', () => {
     const result: ValidationPluginResult = plugin([
       invalidConfiguration,
-      invalidConfigurationMissingEventData,
+      inValidConfigurationNoRsid,
       validConfiguration
     ]);
 
     expect(result).toMatchObject({
       events: [],
+      message: 'Valid! Adobe Analytics Extension has been configured!',
       result: 'matched'
     });
+  });
 
-    const result2: ValidationPluginResult = plugin([
-      invalidConfiguration,
-      invalidConfigurationMissingEventData,
-      alsoValidConfiguration
-    ]);
+  it('should return pass when Analytics configuration is missing properties and no Analytics extension', () => {
+    const result: ValidationPluginResult = plugin([inValidConfigurationNoServer]);
 
-    expect(result2).toMatchObject({
+    expect(result).toMatchObject({
       events: [],
+      message:'no Analytics extension is detected, nothing to validate.',
       result: 'matched'
     });
   });
 
-  it('should return invalid when target configuration is missing properties', () => {
-    const result: ValidationPluginResult = plugin([invalidConfiguration]);
+  it('should return invalid when Analytics configuration is missing event data and Analytics extension exists', () => {
+    const result: ValidationPluginResult = plugin([
+       inValidConfigurationNoRsid,
+       analyticsVersionEvent 
+    ]);
 
     expect(result).toMatchObject({
-      events: ['2'],
+      events: [],
+      message: 'Missing required configuration for Adobe Analytics.',
       result: 'not matched'
     });
   });
 
-  it('should return invalid when target configuration is missing event data', () => {
+  it('should return invalid when Analytics configuration is empty and Analytics extension exists', () => {
     const result: ValidationPluginResult = plugin([
-      invalidConfigurationMissingEventData
+       invalidConfigurationEmpty,
+       analyticsVersionEvent 
     ]);
 
     expect(result).toMatchObject({
-      events: ['3'],
+      events: [],
+      message: 'Missing required configuration for Adobe Analytics.',
       result: 'not matched'
+    });
+  });
+
+  it('should return valid when Analytics configuration is valid and Analytics extension exists', () => {
+    const result: ValidationPluginResult = plugin([
+       validConfiguration,
+       analyticsVersionEvent 
+    ]);
+
+    expect(result).toMatchObject({
+      events: [],
+      message: 'Valid! Adobe Analytics Extension has been configured!',
+      result: 'matched'
     });
   });
 });


### PR DESCRIPTION
Currently this validation always show fails while Analytics is not installed.  
Make the changes below:
-  Change to validate the Analytics Server and Analytics RSID in the SharedStateConfig event.
- Add the check with the Analytics extension is existed.  If it doesn't exist, then set to matched with 'no Analytics extension is detected, nothing to validate.' message.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
