### PR TITLE
Update Core configuration validation

### DIFF
--- a/plugins/aep-core-configuration/index.ts
+++ b/plugins/aep-core-configuration/index.ts
@@ -24,16 +24,14 @@ import { ValidationPluginResult } from 'types/validationPlugin';
   const valid = configurationEvents.some((event) => {
     const experienceCloud =
       event.payload.ACPExtensionEventData['experienceCloud.org'];
-    const server =
-      event.payload.ACPExtensionEventData['experienceCloud.server'];
     const sessionTimeout =
       event.payload.ACPExtensionEventData['lifecycle.sessionTimeout'];
-    return experienceCloud && server && sessionTimeout;
+    return experienceCloud && sessionTimeout;
   });
 
   const message = valid
     ? 'Valid! Adobe Core Extension has been configured!'
-    : 'Missing required configuration for Adobe Core';
+    : 'Missing required experienceCloud.org or lifecycle.sessionTimeout configuration for Adobe Core';
   const errors = valid ? [] : configurationEvents.map((event) => event.uuid);
   return {
     events: errors,

--- a/plugins/aep-core-configuration/plugin.json
+++ b/plugins/aep-core-configuration/plugin.json
@@ -5,6 +5,6 @@
     "namespace": "adobe-core-configuration",
     "src": "dist/index.js",
     "type": "validation",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "visibility": ["PUBLIC"]
 }

--- a/plugins/aep-core-configuration/plugin.test.ts
+++ b/plugins/aep-core-configuration/plugin.test.ts
@@ -11,7 +11,6 @@ const validConfiguration = configuration.mock({
   payload: {
     ACPExtensionEventData: {
       'experienceCloud.org': '123',
-      'experienceCloud.server': '123',
       'lifecycle.sessionTimeout': '123'
     }
   }
@@ -21,14 +20,14 @@ const invalidConfiguration = configuration.mock({
   uuid: '2',
   payload: {
     ACPExtensionEventData: {
-      'experienceCloud.org': '123',
-      'experienceCloud.server': ''
+      'experienceCloud.org': '',
+      'lifecycle.sessionTimeout': '123'
     }
   }
 }) as Configuration;
 
 describe('Adobe Core Configuration', () => {
-  it('should return success when cpre has been configured correctly in at least one event', () => {
+  it('should return success when core has been configured correctly in at least one event', () => {
     const result: ValidationPluginResult = plugin([
       invalidConfiguration,
       validConfiguration


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Remove `experienceCloud.server` check, it is no longer required in the core configuration.  
It is causing failure for the validation while it is a required check.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
